### PR TITLE
feat(release): Setup deployment on Bintray

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,51 @@
+# InstantSearch Android Voice
+
+**InstantSearch Android Voice** provides UI components and helpers for adding voice input to your apps.
+
+# Getting started
+
+## Supported platforms
+
+**InstantSearch Insights Android** is supported on Android devices starting from SDK 14 (Ice Cream Sandwich) and is usable from both **Kotlin** and **Java** code.
+
+# Install
+
+Add `jCenter` to your repositories in `build.gradle`
+
+```
+allprojects {
+    repositories {
+        // [...]
+        jcenter()
+    }
+}
+```
+
+Add the following dependency to your `Gradle` file
+
+```gradle
+dependencies {
+    // [...]
+    implementation 'com.algolia.instantsearch-android:voice:1.+'
+    // [...]
+}
+```
+
+## Quick Start
+## Getting Help
+
+- **Need help**? Ask a question to the [Algolia Community](https://discourse.algolia.com/) or on [Stack Overflow](http://stackoverflow.com/questions/tagged/algolia).
+- **Found a bug?** You can open a [GitHub issue](https://github.com/algolia/instantsearch-android-voice/issues/new).
+- **Questions about Algolia?** You can search our [FAQ in our website](https://www.algolia.com/doc/faq/).
+
+
+## Getting involved
+
+* If you **want to contribute** please feel free to **[submit pull requests](https://github.com/algolia/instantsearch-android-voice/pull/new)**.
+* If you **have a feature request** please **[open an
+  issue](https://github.com/algolia/instantsearch-android-voice/issues/new]**.
+* If you use **InstantSearch** in your app, we would love to hear about it! Drop us a line on [discourse](https://discourse.algolia.com/new-topic?title=InstantSearch%20Mobile%20App:&category_id=10&body=I%27m%20using%20InstantSearch%20for...) or [twitter](https://twitter.com/algolia).
+
+# License
+
+InstantSearch Android Insights is [MIT licensed](LICENSE.md).

--- a/build.gradle
+++ b/build.gradle
@@ -1,13 +1,13 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.kotlin_version = '1.2.40'
+    ext.kotlin_version = '1.2.51'
     repositories {
         google()
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.1'
+        classpath 'com.android.tools.build:gradle:3.1.3'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/build.gradle
+++ b/build.gradle
@@ -10,6 +10,8 @@ buildscript {
         classpath 'com.android.tools.build:gradle:3.1.3'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 
+        classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.3'
+        classpath 'com.github.dcendents:android-maven-gradle-plugin:1.5'
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }

--- a/instantsearch.voice/build.gradle
+++ b/instantsearch.voice/build.gradle
@@ -17,7 +17,7 @@ ext {
     LICENSE = 'MIT'
     LICENSE_URL = "http://www.opensource.org/licenses/mit-license.php"
 
-    VERSION = '1.0.0'
+    VERSION = '1.0.1'
     VERSION_DESC = "$NAME - v$VERSION"
 }
 

--- a/instantsearch.voice/build.gradle
+++ b/instantsearch.voice/build.gradle
@@ -51,11 +51,11 @@ task sourcesJar(type: Jar) {
 
 task javadoc(type: Javadoc) {
     source = android.sourceSets.main.java.sourceFiles
-//    classpath += project.files(android.getBootClasspath().join(File.pathSeparator)) // dependencies
+    classpath += project.files(android.getBootClasspath().join(File.pathSeparator)) // dependencies
 //    failOnError false // Errors about classes `R` and `BuildConfig` should not trigger failure
-//    options.optionFiles << file('javadoc.options')
-//    options.links("http://docs.oracle.com/javase/8/docs/api")
-//    options.linksOffline("http://d.android.com/reference", "$System.env.ANDROID_HOME/docs/reference")
+    options.links("http://docs.oracle.com/javase/8/docs/api")
+    options.linksOffline("http://d.android.com/reference", "$System.env.ANDROID_HOME/docs/reference")
+    options.memberLevel = JavadocMemberLevel.PROTECTED
 // TODO: Check generated Javadoc
 }
 

--- a/instantsearch.voice/build.gradle
+++ b/instantsearch.voice/build.gradle
@@ -1,9 +1,28 @@
 apply plugin: 'com.android.library'
+apply plugin: 'maven'
+apply plugin: 'maven-publish'
+apply plugin: 'com.github.dcendents.android-maven'
+
+ext {
+    GROUP = 'com.algolia.instantsearch-android'
+    BASENAME = 'voice'
+    CODENAME = "$GROUP:$BASENAME"
+    NAME = 'InstantSearch Android Voice'
+    DESC = "Easily add Voice search to your Android apps"
+    LABELS = ["voice search", "voice input", "permissions", "voice UI"]
+
+    GITHUB = "algolia/instantsearch-android-voice"
+    WEBSITE = "https://github.com/$GITHUB"
+    REPO = WEBSITE + ".git"
+    LICENSE = 'MIT'
+    LICENSE_URL = "http://www.opensource.org/licenses/mit-license.php"
+
+    VERSION = '1.0.0'
+    VERSION_DESC = "$NAME - v$VERSION"
+}
 
 android {
     compileSdkVersion 27
-
-
 
     defaultConfig {
         minSdkVersion 14
@@ -24,6 +43,43 @@ android {
 
 }
 
+task sourcesJar(type: Jar) {
+    dependsOn "assembleRelease"
+    classifier "sources"
+    from android.sourceSets.main.java.srcDirs
+}
+
+task javadoc(type: Javadoc) {
+    source = android.sourceSets.main.java.sourceFiles
+//    classpath += project.files(android.getBootClasspath().join(File.pathSeparator)) // dependencies
+//    failOnError false // Errors about classes `R` and `BuildConfig` should not trigger failure
+//    options.optionFiles << file('javadoc.options')
+//    options.links("http://docs.oracle.com/javase/8/docs/api")
+//    options.linksOffline("http://d.android.com/reference", "$System.env.ANDROID_HOME/docs/reference")
+// TODO: Check generated Javadoc
+}
+
+afterEvaluate {
+    // we need this as javadoc task's body is called before android.libraryVariants is filled. http://stackoverflow.com/a/34572606/3109189
+    javadoc.classpath += files(android.libraryVariants.collect { variant ->
+        variant.getJavaCompiler().classpath.files
+    })
+}
+
+task javadocJar(type: Jar, dependsOn: javadoc) {
+    from javadoc.destinationDir
+    classifier "javadoc"
+}
+
+// add sources jar tasks as artifacts
+artifacts {
+    archives sourcesJar
+    archives javadocJar
+    archives file: new File("${project.buildDir}/outputs/aar/${project.name}-release.aar"),
+            name: "${project.name}-release.aar",
+            type: "aar"
+}
+
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
 
@@ -34,3 +90,5 @@ dependencies {
     androidTestImplementation 'com.android.support.test:runner:1.0.2'
     androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'
 }
+
+apply from: "https://raw.githubusercontent.com/algolia/instantsearch-mobile-tools/7b9e6e1cc28f12497b88b6868ab99d5884f7c86b/gradle/bintrayv.gradle"


### PR DESCRIPTION
Applying from `feat/bintrayMetadata` until we merge algolia/instantsearch-mobile-tools#1.

(Tested and successfully released 1.0.1 after [merging master in my tools PR](https://github.com/algolia/instantsearch-mobile-tools/pull/1/commits/7b9e6e1cc28f12497b88b6868ab99d5884f7c86b), which I take as a confirmation that once merged we can replace `apply from:` links to use master directly)