### PR TITLE
refactor: Permission dialog now uses arguments.

### DIFF
--- a/app/src/main/java/com/algolia/instantsearch/voice/demo/MainActivity.kt
+++ b/app/src/main/java/com/algolia/instantsearch/voice/demo/MainActivity.kt
@@ -1,6 +1,7 @@
 package com.algolia.instantsearch.voice.demo
 
 import android.os.Bundle
+import android.support.v7.app.AlertDialog
 import android.support.v7.app.AppCompatActivity
 import com.algolia.instantsearch.voice.Voice
 import com.algolia.instantsearch.voice.ui.PermissionDialogFragment
@@ -16,7 +17,10 @@ class MainActivity : AppCompatActivity(), VoiceInput.VoiceResultsListener {
 
         button.setOnClickListener {
             if (!Voice.hasRecordPermission(this)) {
-                PermissionDialogFragment().show(supportFragmentManager, "perm")
+                PermissionDialogFragment().let {
+                    it.arguments = PermissionDialogFragment.buildArguments(title = "Voice Search.")
+                    it.show(supportFragmentManager, "perm")
+                }
             } else {
                 val voiceFragment = VoiceDialogFragment() //FIXME: Handle orientation changes, storing state properly
                 voiceFragment.setSuggestions("Something", "Something else")

--- a/instantsearch.voice/src/main/java/com/algolia/instantsearch/voice/Voice.kt
+++ b/instantsearch.voice/src/main/java/com/algolia/instantsearch/voice/Voice.kt
@@ -7,7 +7,7 @@ import android.content.Context
 import android.content.pm.PackageManager
 import android.support.v4.app.ActivityCompat
 import android.support.v4.content.ContextCompat
-import com.algolia.instantsearch.voice.ui.PermissionDialogFragment.Companion.ID_REQ_VOICE_PERM
+import com.algolia.instantsearch.voice.ui.PermissionDialogFragment.Companion.PermissionRequestRecordAudio
 
 /** Helper functions for voice permission handling. */
 object Voice {
@@ -19,12 +19,12 @@ object Voice {
         grantResult[0] == PackageManager.PERMISSION_GRANTED
 
     /** Gets whether the [request's code][requestCode] and [results][grantResults] are valid, by respectively checking
-     * that it matches the [request identifier][ID_REQ_VOICE_PERM] and that they are not empty.
+     * that it matches the [request identifier][PermissionRequestRecordAudio] and that they are not empty.
      *
      */
     @JvmStatic
     fun isRecordPermissionWithResults(requestCode: Int, grantResults: IntArray) =
-        requestCode == ID_REQ_VOICE_PERM && grantResults.isNotEmpty()
+        requestCode == PermissionRequestRecordAudio && grantResults.isNotEmpty()
 
     /**
      * Gets whether your application was granted the [recording permission][RECORD_AUDIO].

--- a/instantsearch.voice/src/main/java/com/algolia/instantsearch/voice/ui/PermissionDialogFragment.kt
+++ b/instantsearch.voice/src/main/java/com/algolia/instantsearch/voice/ui/PermissionDialogFragment.kt
@@ -9,31 +9,52 @@ import android.support.v4.app.DialogFragment
 
 class PermissionDialogFragment : DialogFragment() {
 
-    var title = DEFAULT_TITLE
-    var message = DEFAULT_MESSAGE
-    var positiveButton = DEFAULT_POSITIVE_BUTTON
-    var negativeButton = DEFAULT_NEGATIVE_BUTTON
+    private enum class Argument {
+        Title,
+        Message,
+        PositiveButton,
+        NegativeButton
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        if (arguments == null) {
+            arguments = buildArguments()
+        }
+    }
 
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
-        requireActivity().let { activity ->
-            return AlertDialog.Builder(activity)
-                .setTitle(title)
-                .setMessage(message)
-                .setPositiveButton(positiveButton) { _, _ ->
-                    ActivityCompat.requestPermissions(activity, arrayOf(RECORD_AUDIO), ID_REQ_VOICE_PERM)
-                    dismiss()
-                }
-                .setNegativeButton(negativeButton) { dialog, _ -> dialog.cancel() }
-                .create()
-        }
+        val bundle = arguments!!
+        val title = bundle.getString(Argument.Title.name)
+        val message = bundle.getString(Argument.Message.name)
+        val positiveButton = bundle.getString(Argument.PositiveButton.name)
+        val negativeButton = bundle.getString(Argument.NegativeButton.name)
 
+        return AlertDialog.Builder(requireContext())
+            .setTitle(title)
+            .setMessage(message)
+            .setPositiveButton(positiveButton) { _, _ ->
+                ActivityCompat.requestPermissions(requireActivity(), arrayOf(RECORD_AUDIO), PermissionRequestRecordAudio)
+                dismiss()
+            }
+            .setNegativeButton(negativeButton) { dialog, _ -> dialog.cancel() }
+            .create()
     }
 
     companion object {
-        const val ID_REQ_VOICE_PERM = 1
-        const val DEFAULT_TITLE = "You can use voice search to find results"
-        const val DEFAULT_MESSAGE = "Can we access your device's microphone to enable voice search?"
-        const val DEFAULT_POSITIVE_BUTTON = "Allow microphone access"
-        const val DEFAULT_NEGATIVE_BUTTON = "No"
+
+        const val PermissionRequestRecordAudio = 1
+
+        fun buildArguments(
+            title: String = "You can use voice search to find results",
+            message: String = "Can we access your device's microphone to enable voice search?",
+            positiveButton: String = "Allow microphone access",
+            negativeButton: String = "No"
+        ) = Bundle().also {
+            it.putString(Argument.Title.name, title)
+            it.putString(Argument.Message.name, message)
+            it.putString(Argument.PositiveButton.name, positiveButton)
+            it.putString(Argument.NegativeButton.name, negativeButton)
+        }
     }
 }


### PR DESCRIPTION
- Use arguments instead of public variables in fragment
- I'm more in favor of camel casing const variables:
`RequestPermissionAudio` rather than `REQUEST_PERMISSION_AUDIO`
No need to yell (caps) and I always found that Kotlin required a more "smooth" approach 😆
