### PR TITLE
feat(VoiceDialogFragment): Persist suggestions

### DIFF
--- a/app/src/main/java/com/algolia/instantsearch/voice/demo/MainActivity.kt
+++ b/app/src/main/java/com/algolia/instantsearch/voice/demo/MainActivity.kt
@@ -15,6 +15,8 @@ class MainActivity : AppCompatActivity(), VoiceInput.VoiceResultsListener {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
 
+        val voiceFragment = VoiceDialogFragment()
+
         button.setOnClickListener { _ ->
             if (!Voice.hasRecordPermission(this)) {
                 PermissionDialogFragment().let {
@@ -22,7 +24,6 @@ class MainActivity : AppCompatActivity(), VoiceInput.VoiceResultsListener {
                     it.show(supportFragmentManager, "perm")
                 }
             } else {
-                val voiceFragment = VoiceDialogFragment() //FIXME: Handle orientation changes, storing state properly
                 voiceFragment.setSuggestions("Something", "Something else")
                 voiceFragment.input.language = "en-US"
                 voiceFragment.input.maxResults = 2

--- a/instantsearch.voice/src/main/java/com/algolia/instantsearch/voice/ui/VoiceDialogFragment.kt
+++ b/instantsearch.voice/src/main/java/com/algolia/instantsearch/voice/ui/VoiceDialogFragment.kt
@@ -18,28 +18,28 @@ class VoiceDialogFragment : DialogFragment(), VoiceInput.VoiceInputPresenter {
 
     val input: VoiceInput = VoiceInput(this)
 
-    private var suggestions: ArrayList<String> = arrayListOf()
+    private var suggestions: Array<out String> = arrayOf()
 
     fun setSuggestions(vararg suggestions: String) {
-        this.suggestions = arrayListOf(*suggestions)
+        this.suggestions = suggestions
     }
 
     //region Lifecycle
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
-        savedInstanceState?.let {
-            suggestions = it.getStringArrayList(keySuggestions)
-        }
         return inflater.inflate(R.layout.layout_voice_overlay, null)
     }
 
     override fun onSaveInstanceState(outState: Bundle) {
-        outState.putStringArrayList(keySuggestions, suggestions)
         super.onSaveInstanceState(outState)
+        outState.putStringArray(keySuggestions, suggestions)
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         closeButton.setOnClickListener { dismiss() }
         micButton.setOnClickListener { input.toggleVoiceRecognition() }
+        savedInstanceState?.let {
+            suggestions = it.getStringArray(keySuggestions)
+        }
     }
 
     override fun onAttach(context: Context?) {

--- a/instantsearch.voice/src/main/java/com/algolia/instantsearch/voice/ui/VoiceDialogFragment.kt
+++ b/instantsearch.voice/src/main/java/com/algolia/instantsearch/voice/ui/VoiceDialogFragment.kt
@@ -18,15 +18,24 @@ class VoiceDialogFragment : DialogFragment(), VoiceInput.VoiceInputPresenter {
 
     val input: VoiceInput = VoiceInput(this)
 
-    private var suggestions: List<String> = emptyList()
+    private var suggestions: ArrayList<String> = arrayListOf()
 
     fun setSuggestions(vararg suggestions: String) {
-        this.suggestions = listOf(*suggestions)
+        this.suggestions = arrayListOf(*suggestions)
     }
 
     //region Lifecycle
-    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? =
-        inflater.inflate(R.layout.layout_voice_overlay, null)
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
+        savedInstanceState?.let {
+            suggestions = it.getStringArrayList(keySuggestions)
+        }
+        return inflater.inflate(R.layout.layout_voice_overlay, null)
+    }
+
+    override fun onSaveInstanceState(outState: Bundle) {
+        outState.putStringArrayList(keySuggestions, suggestions)
+        super.onSaveInstanceState(outState)
+    }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         closeButton.setOnClickListener { dismiss() }
@@ -53,7 +62,8 @@ class VoiceDialogFragment : DialogFragment(), VoiceInput.VoiceInputPresenter {
     //region Helpers
     companion object {
 
-        const val SEPARATOR = "• "
+        const val separator = "• "
+        const val keySuggestions = "keySuggestions"
     }
     //endregion
 
@@ -66,7 +76,7 @@ class VoiceDialogFragment : DialogFragment(), VoiceInput.VoiceInputPresenter {
             hint.visibility = View.GONE
         } else {
             hint.visibility = View.VISIBLE
-            suggestionText.text = suggestions.fold("") { acc, it -> "$acc$SEPARATOR$it\n" }
+            suggestionText.text = suggestions.fold("") { acc, it -> "$acc$separator$it\n" }
         }
     }
 


### PR DESCRIPTION
Persistence of VoiceDialogFragment's state. 
I considered persisting `VoiceInput.State` too, but realized that it would require moving away from 
```kotlin
    override fun onPause() {
        super.onPause()
        input.stopVoiceRecognition()
    }

    override fun onResume() {
        super.onResume()
        input.startVoiceRecognition()
    }
```
to a more complicated handling of state. I feel it doesn't deserve the added complexity, as on fragment recreation we likely want to listen anyway (if there was an error/pause before the change, what's the value that restoring this state brings versus just listening again for input?)