### PR TITLE
Feat/customization

### DIFF
--- a/app/src/main/kotlin/com/algolia/instantsearch/voice/demo/MainActivity.kt
+++ b/app/src/main/kotlin/com/algolia/instantsearch/voice/demo/MainActivity.kt
@@ -53,13 +53,14 @@ class MainActivity : AppCompatActivity(), VoiceSpeechRecognizer.ResultsListener 
     private fun showVoiceDialog() {
         getPermissionDialog()?.dismiss()
         (getVoiceDialog() ?: VoiceInputDialogFragment()).let {
-            it.setArguments(
-                "Hey, I just met you",
+            it.setSuggestions("Hey, I just met you",
                 "And this is crazy",
                 "But here's my number",
                 "So call me maybe"
             )
+            it.autoStart = false
             it.show(supportFragmentManager, Tag.Voice.name)
+//            it.start()
         }
     }
 

--- a/app/src/main/kotlin/com/algolia/instantsearch/voice/demo/MainActivity.kt
+++ b/app/src/main/kotlin/com/algolia/instantsearch/voice/demo/MainActivity.kt
@@ -5,6 +5,9 @@ import android.support.v7.app.AppCompatActivity
 import android.view.View
 import com.algolia.instantsearch.voice.VoiceSpeechRecognizer
 import com.algolia.instantsearch.voice.ui.Voice
+import com.algolia.instantsearch.voice.ui.Voice.isRecordAudioPermissionGranted
+import com.algolia.instantsearch.voice.ui.Voice.shouldExplainPermission
+import com.algolia.instantsearch.voice.ui.Voice.showPermissionRationale
 import com.algolia.instantsearch.voice.ui.VoiceInputDialogFragment
 import com.algolia.instantsearch.voice.ui.VoicePermissionDialogFragment
 import kotlinx.android.synthetic.main.main.*
@@ -23,7 +26,7 @@ class MainActivity : AppCompatActivity(), VoiceSpeechRecognizer.ResultsListener 
         setContentView(R.layout.main)
 
         main.buttonVoice.setOnClickListener { _ ->
-            if (!Voice.isRecordAudioPermissionGranted(this)) {
+            if (!isRecordAudioPermissionGranted()) {
                 VoicePermissionDialogFragment().show(supportFragmentManager, Tag.Permission.name)
             } else {
                 showVoiceDialog()
@@ -44,7 +47,7 @@ class MainActivity : AppCompatActivity(), VoiceSpeechRecognizer.ResultsListener 
         if (Voice.isRecordPermissionWithResults(requestCode, grantResults)) {
             when {
                 Voice.isPermissionGranted(grantResults) -> showVoiceDialog()
-                Voice.shouldExplainPermission(this) -> Voice.showPermissionRationale(getPermissionView(), this)
+                shouldExplainPermission() -> showPermissionRationale(getPermissionView())
                 else -> Voice.showPermissionManualInstructions(getPermissionView())
             }
         }

--- a/app/src/main/kotlin/com/algolia/instantsearch/voice/demo/MainActivity.kt
+++ b/app/src/main/kotlin/com/algolia/instantsearch/voice/demo/MainActivity.kt
@@ -58,9 +58,7 @@ class MainActivity : AppCompatActivity(), VoiceSpeechRecognizer.ResultsListener 
                 "But here's my number",
                 "So call me maybe"
             )
-            it.autoStart = false
             it.show(supportFragmentManager, Tag.Voice.name)
-//            it.start()
         }
     }
 

--- a/ui/src/main/kotlin/com/algolia/instantsearch/voice/ui/Voice.kt
+++ b/ui/src/main/kotlin/com/algolia/instantsearch/voice/ui/Voice.kt
@@ -110,4 +110,4 @@ object Voice {
     }
 }
 
-//TODO: Expose Activity extension methods instead?
+//TODO: Expose Activity extension methods

--- a/ui/src/main/kotlin/com/algolia/instantsearch/voice/ui/Voice.kt
+++ b/ui/src/main/kotlin/com/algolia/instantsearch/voice/ui/Voice.kt
@@ -39,46 +39,45 @@ object Voice {
      * Gets whether your application was granted the [recording permission][RECORD_AUDIO].
      */
     @JvmStatic
-    fun isRecordAudioPermissionGranted(context: Context) =
-        ContextCompat.checkSelfPermission(context, RECORD_AUDIO) == PackageManager.PERMISSION_GRANTED
+    fun Context.isRecordAudioPermissionGranted() =
+        ContextCompat.checkSelfPermission(this, RECORD_AUDIO) == PackageManager.PERMISSION_GRANTED
 
     /**
-     * Gets whether your [activity] should show UI with rationale for requesting the [recording permission][RECORD_AUDIO].
+     * Gets whether your activity should show UI with rationale for requesting the [recording permission][RECORD_AUDIO].
      */
     @JvmStatic
-    fun shouldExplainPermission(activity: Activity) =
-        ActivityCompat.shouldShowRequestPermissionRationale(activity, Manifest.permission.RECORD_AUDIO)
+    fun Activity.shouldExplainPermission() =
+        ActivityCompat.shouldShowRequestPermissionRationale(this, Manifest.permission.RECORD_AUDIO)
 
     /**
-     * Requests the [recording permission][RECORD_AUDIO] from your [activity].*/
+     * Requests the [recording permission][RECORD_AUDIO] from your activity.*/
     @JvmStatic
-    fun requestPermission(activity: Activity) {
-        ActivityCompat.requestPermissions(activity, arrayOf(RECORD_AUDIO), PermissionRequestRecordAudio)
+    fun Activity.requestRecordingPermission() {
+        ActivityCompat.requestPermissions(this, arrayOf(RECORD_AUDIO), PermissionRequestRecordAudio)
     }
 
-    /** Opens the application's settings from a given [context], so the user can enable recording permission.*/
+    /** Opens the application's settings from a given context, so the user can enable the recording permission.*/
     @JvmStatic
-    fun openAppSettings(context: Context) {
-        context.startActivity(Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS)
-            .setData(Uri.fromParts("package", context.packageName, null)))
+    fun Context.openAppSettings() {
+        startActivity(Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS)
+            .setData(Uri.fromParts("package", packageName, null)))
     }
 
     /** Displays the rationale behind requesting the recording permission via a [Snackbar].
      * @param anchor the view on which the SnackBar will be anchored.
-     * @param activity the activity which would request the permission.
      * @param whyAllow a description of why the permission should be granted.
      * @param buttonAllow a call to action for granting the permission.
      * */
     @JvmStatic
-    fun showPermissionRationale(
+    @JvmOverloads
+    fun Activity.showPermissionRationale(
         anchor: View,
-        activity: Activity,
         whyAllow: CharSequence? = null,
         buttonAllow: CharSequence? = null
     ) {
-        val whyText = whyAllow ?: activity.getString(R.string.permission_rationale)
-        val buttonText = (buttonAllow ?: activity.getString(R.string.permission_button_again))
-        Snackbar.make(anchor, whyText, Snackbar.LENGTH_LONG).setAction(buttonText) { requestPermission(activity) }.show()
+        val whyText = whyAllow ?: getString(R.string.permission_rationale)
+        val buttonText = (buttonAllow ?: getString(R.string.permission_button_again))
+        Snackbar.make(anchor, whyText, Snackbar.LENGTH_LONG).setAction(buttonText) { requestRecordingPermission() }.show()
     }
 
     /** Guides the user to manually enable recording permission in the app's settings.
@@ -88,6 +87,7 @@ object Voice {
      * @param howEnable instructions to manually enable the permission in settings.
      * */
     @JvmStatic
+    @JvmOverloads
     fun showPermissionManualInstructions(
         anchor: View,
         whyEnable: CharSequence? = null,
@@ -102,12 +102,10 @@ object Voice {
         val snackbar = Snackbar.make(anchor, whyText, Snackbar.LENGTH_LONG).setAction(buttonText) {
             Snackbar.make(anchor, howText, Snackbar.LENGTH_SHORT)
                 .addCallback(object : BaseTransientBottomBar.BaseCallback<Snackbar>() {
-                    override fun onDismissed(transientBottomBar: Snackbar?, event: Int) = openAppSettings(context)
+                    override fun onDismissed(transientBottomBar: Snackbar?, event: Int) = context.openAppSettings()
                 }).show()
         }
         (snackbar.view.findViewById(android.support.design.R.id.snackbar_text) as TextView).maxLines = 2
         snackbar.show()
     }
 }
-
-//TODO: Expose Activity extension methods

--- a/ui/src/main/kotlin/com/algolia/instantsearch/voice/ui/VoiceAndroidView.kt
+++ b/ui/src/main/kotlin/com/algolia/instantsearch/voice/ui/VoiceAndroidView.kt
@@ -34,17 +34,13 @@ class VoiceAndroidView(
         view.suggestions.text = html
     }
 
-    override fun setTitle(title: VoiceUI.Title) {
-        view.voiceInput.title.setText(title.resource)
-    }
+    override fun setTitle(title: VoiceUI.Title) = view.voiceInput.title.setText(title.resource)
 
     override fun setSubtitle(subtitle: String) {
         view.voiceInput.subtitle.text = subtitle
     }
 
-    override fun setSubtitle(subtitle: VoiceUI.Subtitle) {
-        view.voiceInput.subtitle.setText(subtitle.resource)
-    }
+    override fun setSubtitle(subtitle: VoiceUI.Subtitle) = view.voiceInput.subtitle.setText(subtitle.resource)
 
     override fun setSuggestionVisibility(isVisible: Boolean) {
         view.voiceInput.suggestions.visibility = if (isVisible) View.VISIBLE else View.INVISIBLE
@@ -54,9 +50,8 @@ class VoiceAndroidView(
         view.voiceInput.hint.visibility = if (isVisible) View.VISIBLE else View.INVISIBLE
     }
 
-    override fun setRippleActivity(isActive: Boolean) {
+    override fun setRippleActivity(isActive: Boolean) =
         if (isActive) view.voiceInput.ripple.start() else view.voiceInput.ripple.cancel()
-    }
 
     override fun setMicrophoneState(state: VoiceMicrophone.State) {
         view.voiceInput.microphone.state = state

--- a/ui/src/main/kotlin/com/algolia/instantsearch/voice/ui/VoiceAndroidView.kt
+++ b/ui/src/main/kotlin/com/algolia/instantsearch/voice/ui/VoiceAndroidView.kt
@@ -34,7 +34,9 @@ class VoiceAndroidView(
         view.suggestions.text = html
     }
 
-    override fun setTitle(title: VoiceUI.Title) = view.voiceInput.title.setText(title.resource)
+    override fun setTitle(title: VoiceUI.Title) {
+        view.voiceInput.title.setText(title.resource)
+    }
 
     override fun setSubtitle(subtitle: String) {
         view.voiceInput.subtitle.text = subtitle

--- a/ui/src/main/kotlin/com/algolia/instantsearch/voice/ui/VoiceInputDialogFragment.kt
+++ b/ui/src/main/kotlin/com/algolia/instantsearch/voice/ui/VoiceInputDialogFragment.kt
@@ -54,9 +54,8 @@ class VoiceInputDialogFragment : DialogFragment() {
         suggestions = arguments?.getStringArray(Field.Suggestions.name)
     }
 
-    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
-        return inflater.inflate(R.layout.voice_input, container, false)
-    }
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? =
+        inflater.inflate(R.layout.voice_input, container, false)
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)

--- a/ui/src/main/kotlin/com/algolia/instantsearch/voice/ui/VoiceInputDialogFragment.kt
+++ b/ui/src/main/kotlin/com/algolia/instantsearch/voice/ui/VoiceInputDialogFragment.kt
@@ -12,20 +12,41 @@ import kotlinx.android.synthetic.main.voice_input.*
 class VoiceInputDialogFragment : DialogFragment() {
 
     private enum class Field {
-        Suggestions
+        Suggestions,
+        AutoStart
     }
 
     private lateinit var speechRecognizer: VoiceSpeechRecognizer
 
-    private var suggestions: Array<out String>? = null
-
-    /** Defines suggestions to display to the user before they speak. */
-    fun setArguments(vararg suggestions: String) {
-        arguments = Bundle().also {
-            it.putStringArray(Field.Suggestions.name, suggestions)
+    /** suggestions to display to the user before they speak. */
+    var suggestions: Array<out String>? = null
+        @JvmName("setSuggestionsArray")
+        set(value) {
+            if (arguments == null) {
+                arguments = Bundle()
+            }
+            arguments?.putStringArray(Field.Suggestions.name, value)
+            field = value
         }
+
+    /** set to `false` if you want to manually [start] the voice recognition. */
+    var autoStart: Boolean = true
+        set(value) {
+            if (arguments == null) arguments = Bundle()
+            arguments?.putBoolean(Field.AutoStart.name, value)
+            field = value
+        }
+
+    /** Sets [suggestions] to display to the user before they speak. */
+    @Suppress("unused") // Java DX: Expose vararg setter
+    fun setSuggestions(vararg suggestions: String) {
+        this.suggestions = suggestions
     }
 
+    /** Starts listening to user input, in case you disabled [autoStart]. */
+    fun start() = speechRecognizer.start()
+
+    // region Lifecycle
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setStyle(DialogFragment.STYLE_NORMAL, R.style.VoiceDialogTheme)
@@ -60,7 +81,7 @@ class VoiceInputDialogFragment : DialogFragment() {
 
     override fun onResume() {
         super.onResume()
-        speechRecognizer.start()
+        if (autoStart) start()
     }
 
     override fun onPause() {
@@ -72,4 +93,5 @@ class VoiceInputDialogFragment : DialogFragment() {
         super.onDestroy()
         speechRecognizer.destroy()
     }
+    //endregion
 }


### PR DESCRIPTION
- Expose `autoStop`
- Expose Extension functions whenever valuable
  > e.g. I felt turning `isPermissionGranted(grantResult: IntArray)` into `IntArray.isPermissionGranted()` would make sense, but only if done consistently with `isRecordPermissionWithResults`. 
  > As both `Int.isRecordPermissionWithResults(grantResults: IntArray)` and `IntArray.isRecordPermissionWithResults(requestCode: Int)` would feel weird, I stuck with staticness for both functions.
- Add `@JVMOverloads` when it improves Java DX